### PR TITLE
fix(auth): skip PIN on public pages and force Dropbox reauth

### DIFF
--- a/components/security/session-guard.tsx
+++ b/components/security/session-guard.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
+import { usePathname } from "next/navigation"
 import { SessionManager } from "@/lib/session-manager"
 import { useAuthentication } from "@/hooks/use-authentication"
 import { SecurePinManager } from "@/lib/secure-pin-manager"
@@ -489,10 +490,16 @@ function SessionPinScreen({ onUnlock, onError, onEmergencyPinUsed, onNewPinSetup
 }
 
 export function SessionGuard({ children }: SessionGuardProps) {
+  const pathname = usePathname()
   const { isAuthenticated, hasPin, validatePin, validateEmergencyPin } = useAuthentication()
   const [sessionInvalidated, setSessionInvalidated] = useState(false)
   const [emergencyPinUsed, setEmergencyPinUsed] = useState(false)
   const [showNewPinSetup, setShowNewPinSetup] = useState(false)
+  const isPublicRoute =
+    pathname === "/welcome" ||
+    pathname === "/releases" ||
+    pathname === "/dropbox-callback" ||
+    pathname === "/onboarding"
 
   useEffect(() => {
     // Listen for session expiry events
@@ -517,6 +524,11 @@ export function SessionGuard({ children }: SessionGuardProps) {
   }, [hasPin])
 
   const showPinScreen = hasPin && (!isAuthenticated || (sessionInvalidated && !SessionManager.isSessionValid()))
+
+  // Public pages shouldn't require wallet unlock because they don't need access to private wallet data.
+  if (isPublicRoute) {
+    return <>{children}</>
+  }
 
   // If no PIN is required or user is authenticated with valid session, show children
   if (!hasPin || (isAuthenticated && !showPinScreen && !showNewPinSetup)) {

--- a/components/settings/data-settings.tsx
+++ b/components/settings/data-settings.tsx
@@ -238,7 +238,12 @@ export function DataSettings() {
     }
 
     const redirectUri = `${window.location.origin}/dropbox-callback`
-    const { authUrl } = await Dropbox.createDropboxAuthRequest(dropboxAppKey, redirectUri)
+    const { authUrl } = await Dropbox.createDropboxAuthRequest(dropboxAppKey, redirectUri, {
+      // Force Dropbox to show a fresh auth flow so disconnect/reconnect doesn't silently reuse
+      // the browser's currently signed-in account without giving the user a choice.
+      forceReapprove: true,
+      forceReauthentication: true,
+    })
     const authWindow = window.open(authUrl, "dropbox-auth", "width=480,height=640")
 
     if (!authWindow) {

--- a/lib/dropbox.ts
+++ b/lib/dropbox.ts
@@ -42,6 +42,8 @@ export function buildDropboxAuthUrl(
     codeChallengeMethod?: "S256" | "plain"
     tokenAccessType?: "online" | "offline"
     scope?: string | readonly string[]
+    forceReapprove?: boolean
+    forceReauthentication?: boolean
   } = {},
 ): string {
   const params = new URLSearchParams({
@@ -58,6 +60,8 @@ export function buildDropboxAuthUrl(
     const scope = typeof options.scope === "string" ? options.scope : options.scope.join(" ")
     params.set("scope", scope)
   }
+  if (options.forceReapprove) params.set("force_reapprove", "true")
+  if (options.forceReauthentication) params.set("force_reauthentication", "true")
 
   return `https://www.dropbox.com/oauth2/authorize?${params.toString()}`
 }
@@ -219,6 +223,7 @@ async function createCodeChallenge(codeVerifier: string): Promise<string> {
 export async function createDropboxAuthRequest(
   appKey: string,
   redirectUri: string,
+  options: { forceReapprove?: boolean; forceReauthentication?: boolean } = {},
 ): Promise<{ authUrl: string; state: string }> {
   if (typeof window === "undefined") {
     throw new Error("Dropbox authorization is only available in the browser")
@@ -239,6 +244,8 @@ export async function createDropboxAuthRequest(
       codeChallengeMethod: "S256",
       tokenAccessType: "offline",
       scope: DROPBOX_REQUIRED_SCOPES,
+      forceReapprove: options.forceReapprove,
+      forceReauthentication: options.forceReauthentication,
     }),
     state,
   }


### PR DESCRIPTION
Allow SessionGuard to bypass wallet unlock on public routes (`/welcome`, `/releases`, `/dropbox-callback`, `/onboarding`) so users can access non-sensitive pages without a PIN prompt.

Also update Dropbox OAuth flow to support and enable `force_reapprove` and `force_reauthentication`, ensuring disconnect/reconnect always shows a fresh account selection instead of silently reusing the current browser session.fix(auth): skip PIN on public pages and force Dropbox reauth

Allow SessionGuard to bypass wallet unlock on public routes (`/welcome`, `/releases`, `/dropbox-callback`, `/onboarding`) so users can access non-sensitive pages without a PIN prompt.

Also update Dropbox OAuth flow to support and enable `force_reapprove` and `force_reauthentication`, ensuring disconnect/reconnect always shows a fresh account selection instead of silently reusing the current browser session.